### PR TITLE
Adding support to pass yaml config file on command line

### DIFF
--- a/src/main/groovy/com/okta/test/mock/application/ApplicationTestRunner.groovy
+++ b/src/main/groovy/com/okta/test/mock/application/ApplicationTestRunner.groovy
@@ -116,9 +116,15 @@ abstract class ApplicationTestRunner extends HttpMock {
     }
 
     ApplicationUnderTest getApplicationUnderTest(String scenarioName) {
+        Config config
 
-        Config config = new Yaml().loadAs(getClass().getResource( '/testRunner.yml' ).text, Config)
-
+        if (System.getProperty("config") != null) {
+            File yamlFile = new File(System.getProperty("config"))
+            config = new Yaml().loadAs(new FileInputStream(yamlFile), Config)
+        } else {
+            config = new Yaml().loadAs(getClass().getResource( '/testRunner.yml' ).text, Config)
+        }
+        
         Class impl = Class.forName(config.implementation)
         scenario = config.scenarios.get(scenarioName)
 


### PR DESCRIPTION
You can now pass the testRunner.yml file as '-Dconfig=/path/to/config'

Addresses the issue - https://github.com/okta/okta-oidc-tck/issues/4