### PR TITLE
Centralize common selenium configuration

### DIFF
--- a/e2e-tests/custom-login/conf.js
+++ b/e2e-tests/custom-login/conf.js
@@ -11,60 +11,10 @@
  */
 
 /* eslint import/no-unresolved:0, import/no-extraneous-dependencies:0, no-console:0 */
-/* global jasmine */
-const jasmineReporters = require('jasmine-reporters');
 const daemonUtil = require('../tools/daemon-util');
+const commonConfig = require('../tools/common-config');
 
-const promises = Promise.all([
+module.exports.config = commonConfig.configure(Promise.all([
   daemonUtil.startCustomLoginServer(),
   daemonUtil.startResourceServer()
-]);
-
-const config = {
-  // Set the following env vars to match your test environment
-  // Note the USERNAME should be of the form "username@email.com"
-  params: {
-    login: {
-      username: process.env.USERNAME,
-      password: process.env.PASSWORD,
-      email: process.env.USERNAME,
-    },
-    // App servers start on port 8080 but configurable using env var
-    appPort: process.env.PORT || 8080,
-    appTimeOut: process.env.TIMEOUT || 1000
-  },
-  framework: 'jasmine2',
-  beforeLaunch() {
-    return promises;
-  },
-  onPrepare() {
-    jasmine.getEnv().addReporter(new jasmineReporters.JUnitXmlReporter({
-      savePath: 'build2/reports/junit',
-      filePrefix: 'results',
-    }));
-  },
-  afterLaunch() {
-    promises.then((childProcesses) => {
-      childProcesses.forEach(child => child.stop());
-    });
-    return new Promise(resolve => setTimeout(() => resolve(), browser.params.appTimeOut));
-  },
-  specs: ['specs/*.js'],
-  restartBrowserBetweenTests: false,
-  capabilities: {},
-};
-
-// Run Headless chrome in Travis, else Chrome
-if (process.env.TRAVIS) {
-  console.log('-- Using Chrome Headless --');
-  config.capabilities = {
-    'browserName': 'chrome',
-    chromeOptions: {
-      args: ['--headless','--disable-gpu','--window-size=1600x1200','--no-sandbox']
-    }
-  }
-} else {
-  config.capabilities.browserName = 'chrome';
-}
-
-module.exports.config = config;
+]));

--- a/e2e-tests/okta-hosted-login/conf.js
+++ b/e2e-tests/okta-hosted-login/conf.js
@@ -11,60 +11,10 @@
  */
 
 /* eslint import/no-unresolved:0, import/no-extraneous-dependencies:0, no-console:0 */
-/* global jasmine */
-const jasmineReporters = require('jasmine-reporters');
 const daemonUtil = require('../tools/daemon-util');
+const commonConfig = require('../tools/common-config');
 
-const promises = Promise.all([
+module.exports.config = commonConfig.configure(Promise.all([
   daemonUtil.startOktaHostedLoginServer(),
   daemonUtil.startResourceServer()
-]);
-
-const config = {
-  // Set the following env vars to match your test environment
-  // Note the USERNAME should be of the form "username@email.com"
-  params: {
-    login: {
-      username: process.env.USERNAME,
-      password: process.env.PASSWORD,
-      email: process.env.USERNAME,
-    },
-    // App servers start on port 8080 but configurable using env var
-    appPort: process.env.PORT || 8080,
-    appTimeOut: process.env.TIMEOUT || 1000
-  },
-  framework: 'jasmine2',
-  beforeLaunch() {
-    return promises;
-  },
-  onPrepare() {
-    jasmine.getEnv().addReporter(new jasmineReporters.JUnitXmlReporter({
-      savePath: 'build2/reports/junit',
-      filePrefix: 'results',
-    }));
-  },
-  afterLaunch() {
-    promises.then((childProcesses) => {
-      childProcesses.forEach(child => child.stop());
-    });
-    return new Promise(resolve => setTimeout(() => resolve(), browser.params.appTimeOut));
-  },
-  specs: ['specs/*.js'],
-  restartBrowserBetweenTests: false,
-  capabilities: {},
-};
-
-// Run Headless chrome in Travis, else Chrome
-if (process.env.TRAVIS) {
-  console.log('-- Using Chrome Headless --');
-  config.capabilities = {
-    'browserName': 'chrome',
-    chromeOptions: {
-      args: ['--headless','--disable-gpu','--window-size=1600x1200','--no-sandbox']
-    }
-  }
-} else {
-  config.capabilities.browserName = 'chrome';
-}
-
-module.exports.config = config;
+]));

--- a/e2e-tests/tools/common-config/index.js
+++ b/e2e-tests/tools/common-config/index.js
@@ -16,7 +16,7 @@
 /* global jasmine */
 const jasmineReporters = require('jasmine-reporters');
 
-var commonConfig = module.exports = {};
+const commonConfig = module.exports = {};
 
 commonConfig.configure = function (promises) {
   const config = {

--- a/e2e-tests/tools/common-config/index.js
+++ b/e2e-tests/tools/common-config/index.js
@@ -1,3 +1,18 @@
+/*
+ * Copyright 2017 Okta
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 /* global jasmine */
 const jasmineReporters = require('jasmine-reporters');
 

--- a/e2e-tests/tools/common-config/index.js
+++ b/e2e-tests/tools/common-config/index.js
@@ -1,0 +1,63 @@
+/* global jasmine */
+const jasmineReporters = require('jasmine-reporters');
+
+var commonConfig = module.exports = {};
+
+commonConfig.configure = function (promises) {
+  const config = {
+    // Set the following env vars to match your test environment
+    // Note the USERNAME should be of the form "username@email.com"
+    params: {
+      login: {
+        username: process.env.USERNAME,
+        password: process.env.PASSWORD,
+        email: process.env.USERNAME,
+      },
+      // App servers start on port 8080 but configurable using env var
+      appPort: process.env.PORT || 8080,
+      appTimeOut: process.env.TIMEOUT || 1000
+    },
+    framework: 'jasmine2',
+    beforeLaunch() {
+      return promises;
+    },
+    onPrepare() {
+      jasmine.getEnv().addReporter(new jasmineReporters.JUnitXmlReporter({
+        savePath: 'build2/reports/junit',
+        filePrefix: 'results',
+      }));
+    },
+    afterLaunch() {
+      promises.then((childProcesses) => {
+        childProcesses.forEach(child => child.stop());
+      });
+      return new Promise(resolve => setTimeout(() => resolve(), browser.params.appTimeOut));
+    },
+    specs: ['specs/*.js'],
+    restartBrowserBetweenTests: false,
+    capabilities: {
+      browserName: 'chrome',
+    }
+  };
+
+  if (process.env.SAUCE_USERNAME) {
+    console.log('-- Using SauceLabs --');
+    config.sauceUser = process.env.SAUCE_USERNAME;
+    config.sauceKey = process.env.SAUCE_ACCESS_KEY;
+    config.capabilities.tunnelIdentifier = process.env.TRAVIS_JOB_NUMBER;
+    config.capabilities.build = process.env.TRAVIS_BUILD_NUMBER;
+    config.capabilities.screenResolution = '1600x1200';
+  }
+  // Run Chrome Headless
+  else if (process.env.CHROME_HEADLESS || process.env.TRAVIS) {
+    console.log('-- Using Chrome Headless --');
+    config.capabilities.chromeOptions = {
+      args: ['--headless','--disable-gpu','--window-size=1600x1200']
+    }
+  }
+  // otherwise just launch the browser locally
+  else {
+    console.log('-- Using Chrome --');
+  }
+  return config;
+};


### PR DESCRIPTION
Allow for use of Sauce Labs

Use Sauce Labs when env var: `SAUCE_USERNAME`
Start browser headless when env var `TRAVIS` or` HEADLESS` is set
Fall back to graphical chrome browser (default)

This functions the same as the previous version unless `SAUCE_USERNAME` is set