### PR TITLE
Replace boolean matchers with descriptive ones

### DIFF
--- a/e2e-tests/custom-login/specs/custom-login-flow-spec.js
+++ b/e2e-tests/custom-login/specs/custom-login-flow-spec.js
@@ -38,8 +38,8 @@ describe('Custom Login Flow', () => {
     customSignInPage.waitForPageLoad();
 
     // Verify that curent domain hasn't changed to okta-hosted login, rather a local custom login page
-    expect(customSignInPage.urlContains('okta')).toBe(false);
-    expect(customSignInPage.urlContains(appRoot)).toBe(true);
+    expect(browser.getCurrentUrl()).not.toContain('okta');
+    expect(browser.getCurrentUrl()).toContain(appRoot);
 
     await customSignInPage.login(browser.params.login.username, browser.params.login.password);
     authenticatedHomePage.waitForPageLoad();

--- a/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
+++ b/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
@@ -38,8 +38,8 @@ describe('Okta Hosted Login Flow', () => {
     oktaSignInPage.waitForPageLoad();
 
     // Verify that curent domain has changed to okta-hosted login page
-    expect(oktaSignInPage.urlContains('okta')).toBe(true);
-    expect(oktaSignInPage.urlContains(appRoot)).toBe(false);
+    expect(browser.getCurrentUrl()).toContain('okta');
+    expect(browser.getCurrentUrl()).not.toContain(appRoot);
 
     await oktaSignInPage.login(browser.params.login.username, browser.params.login.password);
     authenticatedHomePage.waitForPageLoad();


### PR DESCRIPTION
Previous error message was "expected false to be true"
It will not report the incorrect URL in the report

NOTE: note I ran into this because somehow I had the wrong sample running for the test, having a descriptive error message would have made troubleshooting much easier.