### PR TITLE
Fixing the "UnhandledPromiseRejectionWarning" while running tests

### DIFF
--- a/e2e-tests/tools/daemon-util/index.js
+++ b/e2e-tests/tools/daemon-util/index.js
@@ -109,7 +109,6 @@ daemonUtil.startResourceServer = () => {
         `tcp:8000`,
       ]
     });
-  } else {
-    return (Promise.resolve());
   }
+  return Promise.resolve();
 }

--- a/e2e-tests/tools/daemon-util/index.js
+++ b/e2e-tests/tools/daemon-util/index.js
@@ -100,10 +100,16 @@ daemonUtil.startCustomLoginServer = () => startAndWait({
 });
 
 // Start the resource server only for implicit flow
-daemonUtil.startResourceServer = () => process.env.TEST_TYPE !== 'implicit' || startAndWait({
-  script: 'resource-server',
-  color: 'green',
-  resources: [
-    `tcp:8000`,
-  ],
-});
+daemonUtil.startResourceServer = () => {
+  if (process.env.TEST_TYPE === 'implicit') {
+    return startAndWait({
+      script: 'resource-server',
+      color: 'green',
+      resources: [
+        `tcp:8000`,
+      ]
+    });
+  } else {
+    return (Promise.resolve());
+  }
+}


### PR DESCRIPTION
* Resource server is started only for implicit flow tests
* For auth code tests if resource server isn't started we still need to return a resolved promise