### PR TITLE
Adds testing for userinfo get for profile.

### DIFF
--- a/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
+++ b/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
@@ -49,6 +49,13 @@ describe('Okta Hosted Login Flow', () => {
     authenticatedHomePage.viewProfile();
     profile.waitForPageLoad();
     expect(profile.getEmailClaim()).toBe(browser.params.login.email);
+    expect(profile.getFamilyNameClaim()).not.toBe('');
+    expect(profile.getGivenNameClaim()).not.toBe('');
+    expect(profile.getLocaleClaim()).not.toBe('');
+    expect(profile.getNameClaim()).not.toBe('');
+    expect(profile.getPreferredUsernameClaim()).not.toBe('');
+    expect(profile.getSubClaim()).not.toBe('');
+    expect(profile.getZoneInfoClaim()).not.toBe('');
   });
 
   it('can access resource server messages after login', async () => {

--- a/e2e-tests/page-objects/shared/profile-page.js
+++ b/e2e-tests/page-objects/shared/profile-page.js
@@ -18,6 +18,13 @@ class ProfilePage {
 
   constructor() {
     this.$emailClaim = $('#claim-email');
+    this.$familyNameClaim = $('#claim-family_name');
+    this.$givenNameClaim = $('#claim-given_name');
+    this.$localeClaim = $('#claim-locale');
+    this.$nameClaim = $('#claim-name');
+    this.$preferredUsernameClaim = $('#claim-preferred_username');
+    this.$subClaim = $('#claim-sub');
+    this.$zoneInfoClaim = $('#claim-zoneinfo');
   }
 
   waitForPageLoad() {
@@ -30,6 +37,34 @@ class ProfilePage {
 
   getEmailClaim() {
     return this.$emailClaim.getText();
+  }
+
+  getFamilyNameClaim() {
+    return this.$familyNameClaim.getText();
+  }
+
+  getGivenNameClaim() {
+    return this.$givenNameClaim.getText();
+  }
+
+  getLocaleClaim() {
+    return this.$localeClaim.getText();
+  }
+
+  getNameClaim() {
+    return this.$nameClaim.getText();
+  }
+
+  getPreferredUsernameClaim() {
+    return this.$preferredUsernameClaim.getText();
+  }
+
+  getSubClaim() {
+    return this.$subClaim.getText();
+  }
+
+  getZoneInfoClaim() {
+    return this.$zoneInfoClaim.getText();
   }
 }
 


### PR DESCRIPTION
This PR adds tests for testing that all claims we expect from the /userinfo endpoint are on the profile page.  this makes sure we are not parsing the id_token or access_token and displaying that stuff.

This should make it so you have to make a request to the /userinfo endpoint and parse the results from that.

All tests are just validating that the claim is not empty since we dont want to limit this to a specific user.  But as long as you request the scope `openid profile email` you will have everything you need for this test to pass.