### PR TITLE
Updates e2e tests to check for trex orgs

### DIFF
--- a/e2e-tests/custom-login/specs/custom-login-flow-spec.js
+++ b/e2e-tests/custom-login/specs/custom-login-flow-spec.js
@@ -17,6 +17,7 @@ const CustomSignInPage = require('../../page-objects/custom-signin-page');
 const AuthenticatedHomePage = require('../../page-objects/shared/authenticated-home-page');
 const ProfilePage = require('../../page-objects/shared/profile-page');
 const MessagesPage = require('../../page-objects/messages-page');
+const url = require('url');
 
 describe('Custom Login Flow', () => {
   const loginHomePage = new LoginHomePage();
@@ -38,10 +39,8 @@ describe('Custom Login Flow', () => {
     customSignInPage.waitForPageLoad();
 
     // Verify that current domain hasn't changed to okta-hosted login, rather a local custom login page
-    const currentUrl = await browser.getCurrentUrl();
-    const isTrexOrg = currentUrl.includes('trex');
-    const isPreviewOrg = currentUrl.includes('okta');
-    expect(isTrexOrg || isPreviewOrg).toBe(false);
+    const urlProperties = url.parse(process.env.ISSUER);
+    expect(browser.getCurrentUrl()).not.toContain(urlProperties.host);
     expect(browser.getCurrentUrl()).toContain(appRoot);
 
     await customSignInPage.login(browser.params.login.username, browser.params.login.password);

--- a/e2e-tests/custom-login/specs/custom-login-flow-spec.js
+++ b/e2e-tests/custom-login/specs/custom-login-flow-spec.js
@@ -37,8 +37,11 @@ describe('Custom Login Flow', () => {
     loginHomePage.clickLoginButton();
     customSignInPage.waitForPageLoad();
 
-    // Verify that curent domain hasn't changed to okta-hosted login, rather a local custom login page
-    expect(browser.getCurrentUrl()).not.toContain('okta');
+    // Verify that current domain hasn't changed to okta-hosted login, rather a local custom login page
+    const currentUrl = await browser.getCurrentUrl();
+    const isTrexOrg = currentUrl.includes('trex');
+    const isPreviewOrg = currentUrl.includes('okta');
+    expect(isTrexOrg || isPreviewOrg).toBe(false);
     expect(browser.getCurrentUrl()).toContain(appRoot);
 
     await customSignInPage.login(browser.params.login.username, browser.params.login.password);

--- a/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
+++ b/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
@@ -17,6 +17,7 @@ const OktaSignInPage = require('../../page-objects/okta-signin-page');
 const AuthenticatedHomePage = require('../../page-objects/shared/authenticated-home-page');
 const ProfilePage = require('../../page-objects/shared/profile-page');
 const MessagesPage = require('../../page-objects/messages-page');
+const url = require('url');
 
 describe('Okta Hosted Login Flow', () => {
   const loginHomePage = new LoginHomePage();
@@ -38,11 +39,8 @@ describe('Okta Hosted Login Flow', () => {
     oktaSignInPage.waitForPageLoad();
 
     // Verify that current domain has changed to okta-hosted login page
-    const currentUrl = await browser.getCurrentUrl();
-    const isTrexOrg = currentUrl.includes('trex');
-    const isPreviewOrg = currentUrl.includes('okta');
-    expect(isTrexOrg || isPreviewOrg).toBe(true);
-    expect(browser.getCurrentUrl()).not.toContain(appRoot);
+    const urlProperties = url.parse(process.env.ISSUER);
+    expect(browser.getCurrentUrl()).toContain(urlProperties.host);
     expect(browser.getCurrentUrl()).not.toContain(appRoot);
 
     await oktaSignInPage.login(browser.params.login.username, browser.params.login.password);

--- a/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
+++ b/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
@@ -37,8 +37,12 @@ describe('Okta Hosted Login Flow', () => {
     loginHomePage.clickLoginButton();
     oktaSignInPage.waitForPageLoad();
 
-    // Verify that curent domain has changed to okta-hosted login page
-    expect(browser.getCurrentUrl()).toContain('okta');
+    // Verify that current domain has changed to okta-hosted login page
+    const currentUrl = await browser.getCurrentUrl();
+    const isTrexOrg = currentUrl.includes('trex');
+    const isPreviewOrg = currentUrl.includes('okta');
+    expect(isTrexOrg || isPreviewOrg).toBe(true);
+    expect(browser.getCurrentUrl()).not.toContain(appRoot);
     expect(browser.getCurrentUrl()).not.toContain(appRoot);
 
     await oktaSignInPage.login(browser.params.login.username, browser.params.login.password);


### PR DESCRIPTION
This fixes the failure in [samples-js-angular](https://github.com/okta/samples-js-angular) repos