### PR TITLE
Updates element selectors for samples-aspnet-webforms

### DIFF
--- a/e2e-tests/page-objects/shared/authenticated-home-page.js
+++ b/e2e-tests/page-objects/shared/authenticated-home-page.js
@@ -17,8 +17,16 @@ const util = require('./util');
 class AuthenticatedHomePage {
 
   constructor() {
-    this.$profileButton = element(by.linkText('Profile'));
-    this.$logoutButton = element(by.linkText('Logout'));
+    this.$profileButton = $('#profile-button');
+    this.$logoutButton = $('#logout-button');
+
+    // For asp.net webforms you can't have ids with hyphens
+    // https://stackoverflow.com/questions/25919471/how-to-get-html-control-by-id-that-has-hyphens
+  	if (__dirname.indexOf('samples-aspnet-webforms') > -1) {
+      this.$profileButton = $('#profileButton');
+      this.$logoutButton = $('#logoutButton');
+    }
+
     this.$messagesLink = element(by.partialLinkText('Messages'));
   }
 

--- a/e2e-tests/page-objects/shared/login-home-page.js
+++ b/e2e-tests/page-objects/shared/login-home-page.js
@@ -17,7 +17,13 @@ const util = require('./util');
 class LoginHomePage {
 
   constructor() {
-    this.$loginButton = element(by.linkText('Login'));
+  	this.$loginButton = $('#login-button');
+
+    // For asp.net webforms you can't have ids with hyphens
+    // https://stackoverflow.com/questions/25919471/how-to-get-html-control-by-id-that-has-hyphens
+  	if (__dirname.indexOf('samples-aspnet-webforms') > -1) {
+      this.$loginButton = $('#loginButton');
+    }
   }
 
   waitForPageLoad() {


### PR DESCRIPTION
* Had to revert the previous change to selectors, as `element(by.linkText('Login'))` would fail in express sample that used button instead of link (All samples use buttons but somehow having a button inside a `<form>` tag fails this selector)
* We will continue using the old scheme but change only for `samples-aspnet-webforms`