### PR TITLE
Adds option to check if server is already started before running e2e tests

### DIFF
--- a/e2e-tests/custom-login/conf.js
+++ b/e2e-tests/custom-login/conf.js
@@ -14,8 +14,13 @@
 const daemonUtil = require('../tools/daemon-util');
 const commonConfig = require('../tools/common-config');
 
+// Don't start the server if it's already started
+if (process.env.SERVER_STARTED === 'true') {
+  module.exports.config = commonConfig.configure();
+}
+
 // Start the resource server only for implicit flow
-if (process.env.TEST_TYPE === 'implicit') {
+else if (process.env.TEST_TYPE === 'implicit') {
   module.exports.config = commonConfig.configure(Promise.all([
     daemonUtil.startCustomLoginServer(),
     daemonUtil.startResourceServer()

--- a/e2e-tests/okta-hosted-login/conf.js
+++ b/e2e-tests/okta-hosted-login/conf.js
@@ -14,8 +14,13 @@
 const daemonUtil = require('../tools/daemon-util');
 const commonConfig = require('../tools/common-config');
 
+// Don't start the server if it's already started
+if (process.env.SERVER_STARTED === 'true') {
+  module.exports.config = commonConfig.configure();
+}
+
 // Start the resource server only for implicit flow
-if (process.env.TEST_TYPE === 'implicit') {
+else if (process.env.TEST_TYPE === 'implicit') {
   module.exports.config = commonConfig.configure(Promise.all([
     daemonUtil.startOktaHostedLoginServer(),
     daemonUtil.startResourceServer()

--- a/e2e-tests/tools/common-config/index.js
+++ b/e2e-tests/tools/common-config/index.js
@@ -50,6 +50,9 @@ commonConfig.configure = function (promises) {
       }));
     },
     afterLaunch() {
+      if (promises == null)
+        return;
+
       promises.then((childProcesses) => {
         childProcesses.forEach(child => child.stop());
       });

--- a/e2e-tests/tools/daemon-util/index.js
+++ b/e2e-tests/tools/daemon-util/index.js
@@ -97,6 +97,11 @@ function startAndWait(opts) {
 }
 
 async function killProcessAtPort(port) {
+  // If server was started manually, we don't need to kill the server
+  if (process.env.SERVER_STARTED === 'true') {
+    return;
+  }
+
   // For aspnet webforms samples, we use iisexpress that is started as system process
   // Using port to kill it doesn't work. Hence killing the process through name
   const iisexpress = await find('name', 'iisexpress.exe');


### PR DESCRIPTION
* Came across an issue in [aspnet webforms e2e tests](https://github.com/okta/samples-aspnet-webforms/tree/master/e2e-tests)
* Since iisexpress server starts as blocking call when `npm run okta-hosted-login-server` is called by the tck test, I'm starting the server manually as a background process
* This change makes sure that the test doesn't start the server, is `SERVER_STARTED` flag is set