### PR TITLE
Add nonce to id token jwts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: java
 jdk:
-- oraclejdk8
+- openjdk8
 addons:
   apt:
     packages:

--- a/pom.xml
+++ b/pom.xml
@@ -40,15 +40,8 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <type>pom</type>
-                <version>2.9.9</version>
+                <version>2.10.0</version>
                 <scope>import</scope>
-            </dependency>
-            
-            <!-- Once 2.9.9.1 is included in the next version of the jackson-bom, this next dep can be removed -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.9.9.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/groovy/com/okta/test/mock/scenarios/NonceHolder.groovy
+++ b/src/main/groovy/com/okta/test/mock/scenarios/NonceHolder.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.test.mock.scenarios
+
+class NonceHolder {
+
+    static NonceHolder self = new NonceHolder()
+
+    private Map<String, String> nonceMap = new HashMap<>()
+
+    static String getNonce(String key) {
+        return self.nonceMap.get(key)
+    }
+
+    static void setNonce(String key, String value) {
+        self.nonceMap.put(key, value)
+    }
+}

--- a/src/main/groovy/com/okta/test/mock/tests/OIDCCodeFlowLocalValidationIT.groovy
+++ b/src/main/groovy/com/okta/test/mock/tests/OIDCCodeFlowLocalValidationIT.groovy
@@ -19,6 +19,7 @@ import com.okta.test.mock.Config
 import com.okta.test.mock.Scenario
 import com.okta.test.mock.application.ApplicationTestRunner
 import com.okta.test.mock.matchers.TckMatchers
+import com.okta.test.mock.scenarios.NonceHolder
 import com.okta.test.mock.wiremock.TestUtils
 import io.restassured.http.ContentType
 import io.restassured.response.ExtractableResponse
@@ -74,6 +75,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         ExtractableResponse initialResponse = given()
@@ -138,6 +140,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_invalidSignatureIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -158,6 +161,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_wrongKeyIdIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -178,6 +182,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_issuedInFutureIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -198,6 +203,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_expiredIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -218,6 +224,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_wrongAudienceIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -238,6 +245,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_invalidIssuerIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -258,6 +266,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_invalidNotBeforeIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(given()
@@ -277,6 +286,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_unsignedIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -292,7 +302,20 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
     }
 
     private String getState(String redirectUrl) {
-        return TestUtils.parseQuery(new URL(redirectUrl).query).get("state")[0]
+        return getQueryParamValue(redirectUrl, "state")
+    }
+
+    private String getNonce(String redirectUrl) {
+        return getQueryParamValue(redirectUrl, "nonce")
+    }
+
+    private void setNonce(String redirectUrl, String key) {
+        String nonce = getNonce(redirectUrl)
+        NonceHolder.setNonce(key, nonce)
+    }
+
+    private String getQueryParamValue(String redirectUrl, String paramName) {
+        return TestUtils.parseQuery(new URL(redirectUrl).query).get(paramName)[0]
     }
 
     protected Matcher<?> loginPageMatcher() {

--- a/src/main/groovy/com/okta/test/mock/wiremock/HttpMock.groovy
+++ b/src/main/groovy/com/okta/test/mock/wiremock/HttpMock.groovy
@@ -33,6 +33,7 @@ import org.testng.annotations.AfterClass
 
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.util.function.Function
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import static java.lang.Thread.currentThread
@@ -168,7 +169,17 @@ class GStringTransformer extends ResponseTransformer {
         // merge bindings
         bindings.forEach {params += it}
         // override binds with params if any
-        if (parameters != null) params += parameters
+        if (parameters != null) {
+            params += parameters
+
+            // check if any of the params are functions, if so run them and get the result
+            params.entrySet().each {
+                def value = it.getValue()
+                if (value instanceof Function) {
+                    it.setValue(value.apply(request))
+                }
+            }
+        }
 
         return Response.Builder
                 .like(response)

--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -67,6 +67,10 @@
         <cve>CVE-2019-12384</cve>
         <cve>CVE-2019-12086</cve>
         <cve>CVE-2019-12814</cve>
+        <cve>CVE-2019-14379</cve>
+        <cve>CVE-2019-14439</cve>
+        <cve>CVE-2019-16335</cve>
+        <cve>CVE-2019-14540</cve>
     </suppress>
 
     <suppress>


### PR DESCRIPTION
This breaks some of the original test structure (originally used for access tokens), the stub response needs to add the nonce to the JWT so:
- NonceHolder was added (hackie work around for recording the nonce, and associating it with an identifier for a test)
- OIDC tests have been updated to set the nonce (if/when available)
- Update jackson version and CVE detection