### PR TITLE
Support Spring Security 5.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
             <artifactId>wiremock-standalone</artifactId>
-            <version>2.23.2</version>
+            <version>2.25.1</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -40,15 +40,8 @@
                 <groupId>com.fasterxml.jackson</groupId>
                 <artifactId>jackson-bom</artifactId>
                 <type>pom</type>
-                <version>2.9.9</version>
+                <version>2.10.0</version>
                 <scope>import</scope>
-            </dependency>
-            
-            <!-- Once 2.9.9.1 is included in the next version of the jackson-bom, this next dep can be removed -->
-            <dependency>
-                <groupId>com.fasterxml.jackson.core</groupId>
-                <artifactId>jackson-databind</artifactId>
-                <version>2.9.9.1</version>
             </dependency>
         </dependencies>
     </dependencyManagement>

--- a/src/main/groovy/com/okta/test/mock/application/ApplicationTestRunner.groovy
+++ b/src/main/groovy/com/okta/test/mock/application/ApplicationTestRunner.groovy
@@ -122,14 +122,8 @@ abstract class ApplicationTestRunner extends HttpMock implements IHookable {
     }
 
     ApplicationUnderTest getApplicationUnderTest(String scenarioName) {
-        Config config
 
-        if (System.getProperty("config") != null) {
-            File yamlFile = new File(System.getProperty("config"))
-            config = new Yaml().loadAs(new FileInputStream(yamlFile), Config)
-        } else {
-            config = new Yaml().loadAs(getClass().getResource( '/testRunner.yml' ).text, Config)
-        }
+        Config config = loadConfig()
 
         Class impl = Class.forName(config.implementation)
         scenario = config.scenarios.get(scenarioName)
@@ -170,5 +164,36 @@ abstract class ApplicationTestRunner extends HttpMock implements IHookable {
     int getFreePort() {
         int port = new ServerSocket(0).withCloseable {it.getLocalPort()}
         return port
+    }
+
+    /**
+     * Add some verbose logging (when needed). References to this method should NOT be checked in.
+     */
+    void dump() {
+        println "\nDump:"
+        if (wireMockServer != null) {
+            wireMockServer.getAllServeEvents().each {
+                println(it.getRequest())
+            }
+        }
+    }
+
+    Config loadConfig(String fallbackConfigLocation = configYamlLocation()) {
+        Config config
+        if (System.getProperty("config") != null) {
+            File yamlFile = new File(System.getProperty("config"))
+            config = new Yaml().loadAs(new FileInputStream(yamlFile), Config)
+        } else {
+            config = new Yaml().loadAs(getClass().getResource( fallbackConfigLocation ).text, Config)
+        }
+        return config
+    }
+
+    /**
+     * Returns the location of the configuration yaml file on the classpath.
+     * @return defaults to '/testRunner.yml'
+     */
+    String configYamlLocation() {
+        return '/testRunner.yml'
     }
 }

--- a/src/main/groovy/com/okta/test/mock/scenarios/ImplicitRemoteValidationScenarioDefinition.groovy
+++ b/src/main/groovy/com/okta/test/mock/scenarios/ImplicitRemoteValidationScenarioDefinition.groovy
@@ -20,6 +20,8 @@ import com.github.tomakehurst.wiremock.WireMockServer
 import static com.github.tomakehurst.wiremock.client.WireMock.aResponse
 import static com.github.tomakehurst.wiremock.client.WireMock.containing
 import static com.github.tomakehurst.wiremock.client.WireMock.get
+import static com.github.tomakehurst.wiremock.client.WireMock.matching
+import static com.github.tomakehurst.wiremock.client.WireMock.post
 import static com.github.tomakehurst.wiremock.client.WireMock.urlPathEqualTo
 
 class ImplicitRemoteValidationScenarioDefinition implements ScenarioDefinition {
@@ -46,5 +48,13 @@ class ImplicitRemoteValidationScenarioDefinition implements ScenarioDefinition {
                         .willReturn(aResponse()
                         .withHeader("Content-Type", "application/json;charset=UTF-8")
                         .withBodyFile("userinfo-remote-access-token.json")))
+
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/oauth2/default/v1/introspect"))
+                    .withRequestBody(matching(".*token=some.random.jwt.*"))
+                        .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json;charset=UTF-8")
+                        .withBodyFile("introspect.json")))
+
     }
 }

--- a/src/main/groovy/com/okta/test/mock/scenarios/NonceHolder.groovy
+++ b/src/main/groovy/com/okta/test/mock/scenarios/NonceHolder.groovy
@@ -1,0 +1,31 @@
+/*
+ * Copyright 2018-Present Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.test.mock.scenarios
+
+class NonceHolder {
+
+    static NonceHolder self = new NonceHolder()
+
+    private Map<String, String> nonceMap = new HashMap<>()
+
+    static String getNonce(String key) {
+        return self.nonceMap.get(key)
+    }
+
+    static void setNonce(String key, String value) {
+        self.nonceMap.put(key, value)
+    }
+}

--- a/src/main/groovy/com/okta/test/mock/scenarios/OIDCCodeLocalValidationScenarioDefinition.groovy
+++ b/src/main/groovy/com/okta/test/mock/scenarios/OIDCCodeLocalValidationScenarioDefinition.groovy
@@ -371,7 +371,10 @@ class OIDCCodeLocalValidationScenarioDefinition implements ScenarioDefinition {
         @Override
         String apply(Request request) {
             String nonce = NonceHolder.getNonce(nonceKey)
-            return jwtBuilder.claim("nonce", nonce).compact()
+            if (nonce != null) {
+                jwtBuilder.claim("nonce", nonce)
+            }
+            return jwtBuilder.compact()
         }
     }
 }

--- a/src/main/groovy/com/okta/test/mock/scenarios/PkceCodeRemoteValidationScenarioDefinition.groovy
+++ b/src/main/groovy/com/okta/test/mock/scenarios/PkceCodeRemoteValidationScenarioDefinition.groovy
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2017 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.test.mock.scenarios
+
+import com.github.tomakehurst.wiremock.WireMockServer
+import com.okta.test.mock.Config
+import com.okta.test.mock.wiremock.TestUtils
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.SignatureAlgorithm
+import org.apache.commons.codec.binary.Base64
+
+import java.nio.charset.StandardCharsets
+import java.security.KeyPair
+import java.security.KeyPairGenerator
+import java.time.Instant
+import java.time.temporal.ChronoUnit
+import java.util.regex.Pattern
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*
+
+class PkceCodeRemoteValidationScenarioDefinition implements ScenarioDefinition {
+
+    @Override
+    void configureHttpMock(WireMockServer wireMockServer, String baseUrl) {
+
+        def redirectUriPath = Config.Global.codeFlowRedirectPath
+        def redirectUriPathEscaped = URLEncoder.encode(redirectUriPath, StandardCharsets.UTF_8.toString())
+
+        wireMockServer.stubFor(
+                get("/oauth2/default/.well-known/openid-configuration")
+                        .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json")
+                        .withBodyFile("discovery.json")
+                        .withTransformers("gstring-template")))
+
+        wireMockServer.stubFor(
+                get(urlPathEqualTo("/oauth2/default/v1/authorize"))
+                        .withQueryParam("client_id", matching("OOICU812"))
+                        .withQueryParam("redirect_uri", matching(Pattern.quote("http://localhost:") + "\\d+${redirectUriPath}"))
+                        .withQueryParam("response_type", matching("code"))
+                        .withQueryParam("scope", matching("offline_access"))
+                        .withQueryParam("state", matching(".{6,}"))
+                        .withQueryParam("code_challenge_method", matching("S256"))
+                        .withQueryParam("code_challenge", matching(".{10,}"))
+                        .willReturn(aResponse()
+                        .withBody("<html>fake_login_page<html/>")))
+
+        // remote access token
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/oauth2/default/v1/token"))
+                        .withRequestBody(containing("grant_type=authorization_code"))
+                        .withRequestBody(containing("code=TEST_CODE&"))
+                        .withRequestBody(matching(".*" + Pattern.quote("redirect_uri=http%3A%2F%2Flocalhost%3A") + "\\d+" + Pattern.quote(redirectUriPathEscaped) + ".*"))
+                        .withRequestBody(containing("client_id=OOICU812"))
+                        .withRequestBody(matching(".*code_verifier=.{10,}"))
+                        .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json;charset=UTF-8")
+                        .withBodyFile("remote-validation-token.json")))
+
+        wireMockServer.stubFor(
+                get(urlPathEqualTo("/oauth2/default/v1/userinfo"))
+                        .withHeader("Authorization", equalTo("Bearer accessTokenJwt"))
+                        .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json;charset=UTF-8")
+                        .withBodyFile("userinfo.json")))
+
+        // access token with groups
+        wireMockServer.stubFor(
+                post(urlPathEqualTo("/oauth2/default/v1/token"))
+                        .withRequestBody(containing("grant_type=authorization_code"))
+                        .withRequestBody(containing("code=TEST_CODE_WITH_GROUPS&"))
+                        .withRequestBody(matching(".*" + Pattern.quote("redirect_uri=http%3A%2F%2Flocalhost%3A") + "\\d+" + Pattern.quote(redirectUriPathEscaped) + ".*"))
+                        .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json;charset=UTF-8")
+                        .withBodyFile("remote-validation-token-groups.json")))
+
+        wireMockServer.stubFor(
+                get(urlPathEqualTo("/oauth2/default/v1/userinfo"))
+                        .withHeader("Authorization", equalTo("Bearer accessTokenJwt_groups"))
+                        .willReturn(aResponse()
+                        .withHeader("Content-Type", "application/json;charset=UTF-8")
+                        .withBodyFile("userinfo-groups.json")))
+    }
+}

--- a/src/main/groovy/com/okta/test/mock/scenarios/Scenario.groovy
+++ b/src/main/groovy/com/okta/test/mock/scenarios/Scenario.groovy
@@ -17,6 +17,7 @@ package com.okta.test.mock.scenarios
 
 enum Scenario {
     CODE_FLOW_LOCAL_VALIDATION("code-flow-local-validation", new CodeLocalValidationScenarioDefinition()),
+    PKCE_CODE_FLOW_REMOTE_VALIDATION("pkce-code-flow-remote-validation", new PkceCodeRemoteValidationScenarioDefinition()),
     CODE_FLOW_REMOTE_VALIDATION("code-flow-remote-validation", new CodeRemoteValidationScenarioDefinition()),
     CUSTOM_CODE_FLOW_LOCAL_VALIDATION("custom-code-flow-local-validation", new CodeLocalValidationScenarioDefinition()),
     CUSTOM_CODE_FLOW_REMOTE_VALIDATION("custom-code-flow-remote-validation", new CodeRemoteValidationScenarioDefinition()),
@@ -27,6 +28,7 @@ enum Scenario {
     static Map<String, Scenario> LOOKUP_MAP = new HashMap<>()
     static {
         LOOKUP_MAP.put( CODE_FLOW_LOCAL_VALIDATION.id, CODE_FLOW_LOCAL_VALIDATION)
+        LOOKUP_MAP.put( PKCE_CODE_FLOW_REMOTE_VALIDATION.id, PKCE_CODE_FLOW_REMOTE_VALIDATION)
         LOOKUP_MAP.put( CODE_FLOW_REMOTE_VALIDATION.id, CODE_FLOW_REMOTE_VALIDATION)
         LOOKUP_MAP.put( CUSTOM_CODE_FLOW_LOCAL_VALIDATION.id, CUSTOM_CODE_FLOW_LOCAL_VALIDATION)
         LOOKUP_MAP.put( CUSTOM_CODE_FLOW_REMOTE_VALIDATION.id, CUSTOM_CODE_FLOW_REMOTE_VALIDATION)

--- a/src/main/groovy/com/okta/test/mock/tests/CodeFlowLocalValidationIT.groovy
+++ b/src/main/groovy/com/okta/test/mock/tests/CodeFlowLocalValidationIT.groovy
@@ -209,7 +209,7 @@ class CodeFlowLocalValidationIT extends ApplicationTestRunner {
                .follow(false)
         .when()
             .get(requestUrl)
-        .then().log().everything()
+        .then()
             .statusCode(302)
             .header("Location", Matchers.equalTo("http://localhost:${applicationPort}/".toString()))
         .extract()
@@ -221,7 +221,7 @@ class CodeFlowLocalValidationIT extends ApplicationTestRunner {
                 .follow(false)
         .when()
             .get("http://localhost:${applicationPort}/")
-        .then().log().everything()
+        .then()
             .spec(statusCodeMatcher(403))
     }
 

--- a/src/main/groovy/com/okta/test/mock/tests/ImplicitRemoteValidationIT.groovy
+++ b/src/main/groovy/com/okta/test/mock/tests/ImplicitRemoteValidationIT.groovy
@@ -21,6 +21,7 @@ import io.restassured.http.ContentType
 import org.testng.annotations.Test
 
 import static io.restassured.RestAssured.given
+import static org.hamcrest.Matchers.containsString
 import static org.hamcrest.Matchers.startsWith
 import static com.okta.test.mock.scenarios.Scenario.IMPLICIT_FLOW_REMOTE_VALIDATION
 
@@ -36,7 +37,7 @@ class ImplicitRemoteValidationIT extends ApplicationTestRunner {
             .get("http://localhost:${applicationPort}/api/messages")
         .then()
             .statusCode(401)
-            .header("WWW-Authenticate", startsWith("Bearer realm="))
+            .header("WWW-Authenticate", startsWith("Bearer"))
     }
 
     @Test
@@ -47,6 +48,19 @@ class ImplicitRemoteValidationIT extends ApplicationTestRunner {
                 .follow(false)
         .when()
             .get("http://localhost:${applicationPort}/api/messages")
+        .then()
+            .statusCode(200)
+            .body(containsString("I am a robot."))
+    }
+
+    @Test
+    void invalidScopeTest() {
+        given()
+            .header("Authorization", "Bearer some.random.jwt")
+            .redirects()
+                .follow(false)
+        .when()
+            .get("http://localhost:${applicationPort}/api/invalidScope")
         .then()
             .statusCode(403)
     }

--- a/src/main/groovy/com/okta/test/mock/tests/OIDCCodeFlowLocalValidationIT.groovy
+++ b/src/main/groovy/com/okta/test/mock/tests/OIDCCodeFlowLocalValidationIT.groovy
@@ -19,6 +19,7 @@ import com.okta.test.mock.Config
 import com.okta.test.mock.Scenario
 import com.okta.test.mock.application.ApplicationTestRunner
 import com.okta.test.mock.matchers.TckMatchers
+import com.okta.test.mock.scenarios.NonceHolder
 import com.okta.test.mock.wiremock.TestUtils
 import io.restassured.http.ContentType
 import io.restassured.response.ExtractableResponse
@@ -74,6 +75,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         ExtractableResponse initialResponse = given()
@@ -138,6 +140,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_invalidSignatureIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -158,6 +161,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_wrongKeyIdIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -178,6 +182,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_issuedInFutureIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -198,6 +203,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_expiredIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -218,6 +224,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_wrongAudienceIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -238,6 +245,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_invalidIssuerIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -258,6 +266,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_invalidNotBeforeIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(given()
@@ -277,6 +286,7 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
         String redirectUrl = response.header("Location")
         String state = getState(redirectUrl)
         String code = "TEST_CODE_unsignedIdTokenJwt"
+        setNonce(redirectUrl, code)
         String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
 
         assertAccessDenied(
@@ -292,7 +302,20 @@ class OIDCCodeFlowLocalValidationIT extends ApplicationTestRunner {
     }
 
     private String getState(String redirectUrl) {
-        return TestUtils.parseQuery(new URL(redirectUrl).query).get("state")[0]
+        return getQueryParamValue(redirectUrl, "state")
+    }
+
+    private String getNonce(String redirectUrl) {
+        return getQueryParamValue(redirectUrl, "nonce")
+    }
+
+    private void setNonce(String redirectUrl, String key) {
+        String nonce = getNonce(redirectUrl)
+        NonceHolder.setNonce(key, nonce)
+    }
+
+    private String getQueryParamValue(String redirectUrl, String paramName) {
+        return TestUtils.parseQuery(new URL(redirectUrl).query).get(paramName)[0]
     }
 
     protected Matcher<?> loginPageMatcher() {

--- a/src/main/groovy/com/okta/test/mock/tests/PkceCodeFlowRemoteValidationIT.groovy
+++ b/src/main/groovy/com/okta/test/mock/tests/PkceCodeFlowRemoteValidationIT.groovy
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2017 Okta, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package com.okta.test.mock.tests
+
+import com.okta.test.mock.Config
+import com.okta.test.mock.Scenario
+import com.okta.test.mock.application.ApplicationTestRunner
+import com.okta.test.mock.wiremock.TestUtils
+import io.restassured.http.ContentType
+import io.restassured.response.ExtractableResponse
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers
+import org.testng.annotations.Test
+
+import static com.okta.test.mock.matchers.UrlMatcher.singleQueryValue
+import static com.okta.test.mock.matchers.UrlMatcher.urlMatcher
+import static com.okta.test.mock.scenarios.Scenario.PKCE_CODE_FLOW_REMOTE_VALIDATION
+import static io.restassured.RestAssured.given
+import static org.hamcrest.Matchers.isOneOf
+import static org.hamcrest.text.MatchesPattern.matchesPattern
+
+@Scenario(PKCE_CODE_FLOW_REMOTE_VALIDATION)
+class PkceCodeFlowRemoteValidationIT extends ApplicationTestRunner {
+
+    private def redirectUriPath = Config.Global.codeFlowRedirectPath
+
+    ExtractableResponse redirectToRemoteLogin() {
+
+        return given()
+            .redirects()
+                .follow(false)
+            .accept(ContentType.JSON)
+        .when()
+            .get("http://localhost:${applicationPort}${protectedPath}")
+        .then()
+            .statusCode(302)
+            .header("Location", loginPageLocationMatcher())
+        .extract()
+    }
+
+    @Test
+    void followRedirect() {
+        given()
+            .accept(ContentType.JSON)
+        .when()
+            .get("http://localhost:${applicationPort}${protectedPath}")
+        .then()
+            .statusCode(200)
+            .body(loginPageMatcher())
+    }
+
+    @Test
+    void respondWithCode() {
+        ExtractableResponse response = redirectToRemoteLogin()
+        String redirectUrl = response.header("Location")
+        String state = TestUtils.parseQuery(new URL(redirectUrl).query).get("state").get(0)
+        String code = "TEST_CODE"
+        String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
+
+        ExtractableResponse response2 = given()
+            .accept(ContentType.JSON)
+            .cookies(response.cookies())
+            .redirects()
+                .follow(false)
+        .when()
+            .get(requestUrl)
+        .then()
+            .statusCode(302)
+            .header("Location", isOneOf("/", "http://localhost:${applicationPort}/".toString()))
+        .extract()
+
+        given()
+            .accept(ContentType.JSON)
+            .cookies(response2.cookies())
+            .redirects()
+                .follow(false)
+        .when()
+            .get("http://localhost:${applicationPort}/")
+        .then()
+            .body(Matchers.containsString("Welcome home"))
+
+    }
+
+    protected Matcher<?> loginPageMatcher() {
+        return Matchers.equalTo("<html>fake_login_page<html/>")
+    }
+
+    protected Matcher loginPageLocationMatcher() {
+        return urlMatcher("${baseUrl}/oauth2/default/v1/authorize",
+                singleQueryValue("client_id", "OOICU812"),
+                singleQueryValue("redirect_uri", "http://localhost:${applicationPort}${redirectUriPath}"),
+                singleQueryValue("response_type", "code"),
+                singleQueryValue("scope", "offline_access"),
+                singleQueryValue("state", matchesPattern(".{6,}")))
+    }
+
+    @Override
+    String getProtectedPath() {
+        return System.getProperty("redirect.path", super.getProtectedPath())
+    }
+}

--- a/src/main/groovy/com/okta/test/mock/wiremock/HttpMock.groovy
+++ b/src/main/groovy/com/okta/test/mock/wiremock/HttpMock.groovy
@@ -33,6 +33,7 @@ import org.testng.annotations.AfterClass
 
 import java.nio.file.Files
 import java.nio.file.StandardCopyOption
+import java.util.function.Function
 
 import static com.github.tomakehurst.wiremock.core.WireMockConfiguration.wireMockConfig
 import static java.lang.Thread.currentThread
@@ -168,7 +169,17 @@ class GStringTransformer extends ResponseTransformer {
         // merge bindings
         bindings.forEach {params += it}
         // override binds with params if any
-        if (parameters != null) params += parameters
+        if (parameters != null) {
+            params += parameters
+
+            // check if any of the params are functions, if so run them and get the result
+            params.entrySet().each {
+                def value = it.getValue()
+                if (value instanceof Function) {
+                    it.setValue(value.apply(request))
+                }
+            }
+        }
 
         return Response.Builder
                 .like(response)

--- a/src/main/groovy/com/okta/test/mock/wiremock/TestUtils.groovy
+++ b/src/main/groovy/com/okta/test/mock/wiremock/TestUtils.groovy
@@ -17,6 +17,8 @@ package com.okta.test.mock.wiremock
 
 import io.restassured.config.HttpClientConfig
 import io.restassured.config.RestAssuredConfig
+import io.restassured.filter.Filter
+import io.restassured.filter.session.SessionFilter
 import io.restassured.http.ContentType
 import io.restassured.matcher.ResponseAwareMatcher
 import io.restassured.response.ExtractableResponse
@@ -59,7 +61,8 @@ class TestUtils {
     static ExtractableResponse followRedirectUntilLocation(ExtractableResponse response,
                                                            Matcher<Response> responseMatcher,
                                                            int maxRedirects = 3,
-                                                           String baseUrl = "") {
+                                                           String baseUrl = "",
+                                                           Filter filter = new SessionFilter()) {
 
         if (responseMatcher.matches(response)) {
             return response
@@ -80,15 +83,15 @@ class TestUtils {
                 .redirects()
                     .follow(false)
                 .accept(ContentType.JSON)
+                .filter(filter)
             .when()
                 .cookies(response.cookies())
                 .get(location)
             .then()
                 .extract()
 
-            response = tempResponse
-            if (responseMatcher.matches(response)) {
-                return response
+            if (responseMatcher.matches(tempResponse)) {
+                return tempResponse
             }
         }
         assertThat "Exceded max redirect follow of '${maxRedirects}' last location failure: ", response.header("Location"), responseMatcher

--- a/src/main/resources/stubs/__files/introspect-groups.json
+++ b/src/main/resources/stubs/__files/introspect-groups.json
@@ -1,0 +1,19 @@
+{
+    "active": true,
+    "scope": "openid email profile",
+    "username": "joe.coder@example.com",
+    "exp": 1570145925,
+    "iat": 1570142325,
+    "sub": "joe.coder@example.com",
+    "aud": "api://default",
+    "iss": "http://example.com/issuer",
+    "jti": "a-test-jti",
+    "token_type": "Bearer",
+    "client_id": "OOICU812",
+    "uid": "00uid4BxXw6I6TV4m0g3",
+    "email": "joe.coder@example.com",
+        "groups": [
+        "Everyone",
+        "Test-Group"
+    ]
+}

--- a/src/main/resources/stubs/__files/introspect.json
+++ b/src/main/resources/stubs/__files/introspect.json
@@ -1,0 +1,15 @@
+{
+    "active": true,
+    "scope": "openid email profile",
+    "username": "joe.coder@example.com",
+    "exp": 1570145925,
+    "iat": 1570142325,
+    "sub": "joe.coder@example.com",
+    "aud": "api://default",
+    "iss": "http://example.com/issuer",
+    "jti": "a-test-jti",
+    "token_type": "Bearer",
+    "client_id": "OOICU812",
+    "uid": "00uid4BxXw6I6TV4m0g3",
+    "email": "joe.coder@example.com"
+}

--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -64,13 +64,8 @@
         integration tests so we can ignore these.  NOTE: this dependency is ONLY used for a test scope and will NOT
         cause downstream dependencies to use this version of Jackson. ]]></notes>
         <gav regex="true">^com\.fasterxml\.jackson\.core:jackson-databind:.*$</gav>
-        <cve>CVE-2019-12384</cve>
-        <cve>CVE-2019-12086</cve>
-        <cve>CVE-2019-12814</cve>
-        <cve>CVE-2019-14379</cve>
-        <cve>CVE-2019-14439</cve>
-        <cve>CVE-2019-16335</cve>
-        <cve>CVE-2019-14540</cve>
+        <cve>CVE-2019-16942</cve>
+        <cve>CVE-2019-16943</cve>
     </suppress>
 
     <suppress>

--- a/src/owasp/owasp-suppression.xml
+++ b/src/owasp/owasp-suppression.xml
@@ -67,6 +67,10 @@
         <cve>CVE-2019-12384</cve>
         <cve>CVE-2019-12086</cve>
         <cve>CVE-2019-12814</cve>
+        <cve>CVE-2019-14379</cve>
+        <cve>CVE-2019-14439</cve>
+        <cve>CVE-2019-16335</cve>
+        <cve>CVE-2019-14540</cve>
     </suppress>
 
     <suppress>


### PR DESCRIPTION
- PKCE
   - RP-Initiated Logout
   - Opaque token validation
   - minor cleanup of Spring specific code (e.g. header starting with `Bearer
   realm=`)
   - improved reliability of redirect state handling with RESTeasy's
   SessionFilter

Imports (and resolves conflicts from) #68
Fixes: #68