### PR TITLE
Adds AfterAll() block to close webdriver instances

### DIFF
--- a/e2e-tests/custom-login/specs/custom-login-flow-spec.js
+++ b/e2e-tests/custom-login/specs/custom-login-flow-spec.js
@@ -31,6 +31,12 @@ describe('Custom Login Flow', () => {
     browser.ignoreSynchronization = true;
   });
 
+  afterAll(() => {
+    browser.driver.close().then(() => {
+      browser.driver.quit();
+    });
+  });
+
   it('can login with Okta as the IDP using custom signin page', async () => {
     browser.get(appRoot);
     loginHomePage.waitForPageLoad();

--- a/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
+++ b/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
@@ -31,6 +31,12 @@ describe('Okta Hosted Login Flow', () => {
     browser.ignoreSynchronization = true;
   });
 
+  afterAll(() => {
+    browser.driver.close().then(() => {
+      browser.driver.quit();
+    });
+  });
+
   it('can login with Okta as the IDP', async () => {
     browser.get(appRoot);
     loginHomePage.waitForPageLoad();


### PR DESCRIPTION
* On windows platform, chrome driver instances are not closed by default
* The `AfterAll()` ensures that any driver instances are closed after all tests