### PR TITLE
Add _optional_ tests for OIDC clients that map a `groups` claim to an application role / authority

### DIFF
--- a/THIRD-PARTY-NOTICES
+++ b/THIRD-PARTY-NOTICES
@@ -22,11 +22,15 @@ This project includes:
   Hamcrest under BSD License 3
   Hamcrest Core under New BSD License
   Hamcrest library under New BSD License
+  Jackson-annotations under The Apache Software License, Version 2.0
+  Jackson-core under The Apache Software License, Version 2.0
+  jackson-databind under The Apache Software License, Version 2.0
   Java Architecture for XML Binding under CDDL 1.1 or GPL2 w/ CPE
   JAXB OSGI under CDDL+GPL License
   JCL 1.2 implemented over SLF4J under Apache License, Version 2.0
   jcommander under Apache 2.0
   JJWT :: API under Apache License, Version 2.0
+  JJWT :: Extensions :: Jackson under Apache License, Version 2.0
   JJWT :: Impl under Apache License, Version 2.0
   json-path under Apache 2.0
   Logback Classic Module under Eclipse Public License - v 1.0 or GNU Lesser General Public License

--- a/pom.xml
+++ b/pom.xml
@@ -116,6 +116,11 @@
             <version>0.10.7</version>
         </dependency>
         <dependency>
+            <groupId>io.jsonwebtoken</groupId>
+            <artifactId>jjwt-jackson</artifactId>
+            <version>0.10.7</version>
+        </dependency>
+        <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
             <version>1.25</version>

--- a/src/main/groovy/com/okta/test/mock/scenarios/PkceCodeRemoteValidationScenarioDefinition.groovy
+++ b/src/main/groovy/com/okta/test/mock/scenarios/PkceCodeRemoteValidationScenarioDefinition.groovy
@@ -71,6 +71,15 @@ class PkceCodeRemoteValidationScenarioDefinition implements ScenarioDefinition {
                         .withBodyFile("remote-validation-token.json")))
 
         wireMockServer.stubFor(
+                post(urlPathEqualTo("/oauth2/default/v1/token"))
+                        .withRequestBody(containing("grant_type=authorization_code"))
+                        .withRequestBody(containing("code=TEST_CODE_GROUPS&"))
+                        .withRequestBody(matching(".*"+Pattern.quote("redirect_uri=http%3A%2F%2Flocalhost%3A") + "\\d+" +Pattern.quote(redirectUriPathEscaped) +".*"))
+                        .willReturn(aResponse()
+                                .withHeader("Content-Type", "application/json;charset=UTF-8")
+                                .withBodyFile("remote-validation-token-groups.json")))
+
+        wireMockServer.stubFor(
                 get(urlPathEqualTo("/oauth2/default/v1/userinfo"))
                         .withHeader("Authorization", equalTo("Bearer accessTokenJwt"))
                         .willReturn(aResponse()

--- a/src/main/groovy/com/okta/test/mock/tests/BaseValidationIT.groovy
+++ b/src/main/groovy/com/okta/test/mock/tests/BaseValidationIT.groovy
@@ -1,0 +1,88 @@
+package com.okta.test.mock.tests
+
+import com.okta.test.mock.Config
+import com.okta.test.mock.application.ApplicationTestRunner
+import com.okta.test.mock.matchers.TckMatchers
+import io.restassured.filter.Filter
+import io.restassured.filter.cookie.CookieFilter
+import io.restassured.http.ContentType
+import io.restassured.response.ExtractableResponse
+import org.hamcrest.Matcher
+import org.hamcrest.Matchers
+
+import static com.okta.test.mock.matchers.UrlMatcher.singleQueryValue
+import static com.okta.test.mock.matchers.UrlMatcher.singleQueryValue
+import static com.okta.test.mock.matchers.UrlMatcher.singleQueryValue
+import static com.okta.test.mock.matchers.UrlMatcher.singleQueryValue
+import static com.okta.test.mock.matchers.UrlMatcher.singleQueryValue
+import static com.okta.test.mock.matchers.UrlMatcher.urlMatcher
+import static com.okta.test.mock.wiremock.TestUtils.followRedirectUntilLocation
+import static io.restassured.RestAssured.given
+import static org.hamcrest.Matchers.allOf
+import static org.hamcrest.Matchers.containsString
+import static org.hamcrest.text.MatchesPattern.matchesPattern
+
+abstract class BaseValidationIT extends ApplicationTestRunner implements UrlParser {
+
+    protected Matcher<?> loginPageMatcher() {
+        return Matchers.equalTo("<html>fake_login_page<html/>")
+    }
+
+    String getRedirectUriPath() {
+        return Config.Global.codeFlowRedirectPath
+    }
+
+    Matcher loginPageLocationMatcher(String scope="profile email openid") {
+        return urlMatcher("${baseUrl}/oauth2/default/v1/authorize",
+                singleQueryValue("client_id", "OOICU812"),
+                singleQueryValue("redirect_uri", "http://localhost:${applicationPort}${redirectUriPath}"),
+                singleQueryValue("response_type", "code"),
+                singleQueryValue("scope", scope),
+                singleQueryValue("state", matchesPattern(".{6,}")))
+    }
+
+    ExtractableResponse redirectToRemoteLogin() {
+
+        return given()
+                .redirects()
+                .follow(false)
+                .accept(ContentType.JSON)
+            .when()
+                .get("http://localhost:${applicationPort}${protectedPath}")
+            .then()
+                .statusCode(302)
+                .header("Location", loginPageLocationMatcher())
+            .extract()
+    }
+
+    ExtractableResponse doLogin(Filter filter = new CookieFilter(), String code = "TEST_CODE") {
+        ExtractableResponse response = redirectToRemoteLogin()
+        String redirectUrl = response.header("Location")
+        String state = getState(redirectUrl)
+        setNonce(redirectUrl, code)
+        String requestUrl = "http://localhost:${applicationPort}${redirectUriPath}?code=${code}&state=${state}"
+
+        ExtractableResponse initialResponse = given()
+                .filter(filter)
+                .redirects()
+                .follow(false)
+                .accept(ContentType.JSON)
+                .cookies(response.cookies())
+            .when()
+                .get(requestUrl)
+            .then()
+                .extract()
+
+        return followRedirectUntilLocation(initialResponse,
+                allOf(TckMatchers.responseCode(200),
+                        TckMatchers.bodyMatcher(containsString("Welcome home"))),
+                3,
+                "http://localhost:${applicationPort}",
+                filter)
+    }
+
+    @Override
+    String getProtectedPath() {
+        return System.getProperty("redirect.path", super.getProtectedPath())
+    }
+}

--- a/src/main/groovy/com/okta/test/mock/tests/UrlParser.groovy
+++ b/src/main/groovy/com/okta/test/mock/tests/UrlParser.groovy
@@ -1,0 +1,25 @@
+package com.okta.test.mock.tests
+
+import com.okta.test.mock.scenarios.NonceHolder
+import com.okta.test.mock.wiremock.TestUtils
+
+trait UrlParser {
+
+    String getState(String redirectUrl) {
+        return getQueryParamValue(redirectUrl, "state")
+    }
+
+    String getNonce(String redirectUrl) {
+        return getQueryParamValue(redirectUrl, "nonce")
+    }
+
+    void setNonce(String redirectUrl, String key) {
+        String nonce = getNonce(redirectUrl)
+        NonceHolder.setNonce(key, nonce)
+    }
+
+    String getQueryParamValue(String redirectUrl, String paramName) {
+        def value = TestUtils.parseQuery(new URL(redirectUrl).query).get(paramName)
+        return value != null ? value[0] : null
+    }
+}


### PR DESCRIPTION
Extract a common code out to BaseValidationIT and UrlParser