### PR TITLE
Provide default timeout update option

### DIFF
--- a/e2e-tests/custom-login/specs/custom-login-flow-spec.js
+++ b/e2e-tests/custom-login/specs/custom-login-flow-spec.js
@@ -29,6 +29,10 @@ describe('Custom Login Flow', () => {
 
   beforeEach(() => {
     browser.ignoreSynchronization = true;
+    if (process.env.DEFAULT_TIMEOUT_INTERVAL) {
+      console.log(`Setting default timeout interval to ${process.env.DEFAULT_TIMEOUT_INTERVAL}`)
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = process.env.DEFAULT_TIMEOUT_INTERVAL;
+    }
   });
 
   afterAll(() => {

--- a/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
+++ b/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
@@ -29,6 +29,10 @@ describe('Okta Hosted Login Flow', () => {
 
   beforeEach(() => {
     browser.ignoreSynchronization = true;
+    if (process.env.DEFAULT_TIMEOUT_INTERVAL) {
+      console.log(`Setting default timeout interval to ${process.env.DEFAULT_TIMEOUT_INTERVAL}`)
+      jasmine.DEFAULT_TIMEOUT_INTERVAL = process.env.DEFAULT_TIMEOUT_INTERVAL;
+    }
   });
 
   afterAll(() => {


### PR DESCRIPTION
* [React sample tests](https://github.com/okta/samples-js-react) are failing due to timeout
* Sometimes, the react server takes longer time to load, which causes tests to timeout
* This PR provides the user option to increase the default timeout using env var