### PR TITLE
Adds page object for OIE sign-in page

### DIFF
--- a/e2e-tests/custom-login/specs/custom-login-flow-spec.js
+++ b/e2e-tests/custom-login/specs/custom-login-flow-spec.js
@@ -13,7 +13,10 @@
 'use strict';
 
 const LoginHomePage = require('../../page-objects/shared/login-home-page');
-const CustomSignInPage = require('../../page-objects/custom-signin-page');
+let OktaSignInPage = require('../../page-objects/okta-signin-page');
+if (process.env.ORG_OIE_ENABLED) {
+  OktaSignInPage = require('../../page-objects/okta-oie-signin-page');
+}
 const AuthenticatedHomePage = require('../../page-objects/shared/authenticated-home-page');
 const ProfilePage = require('../../page-objects/shared/profile-page');
 const MessagesPage = require('../../page-objects/messages-page');
@@ -21,7 +24,7 @@ const url = require('url');
 
 describe('Custom Login Flow', () => {
   const loginHomePage = new LoginHomePage();
-  const customSignInPage = new CustomSignInPage();
+  const customSignInPage = new OktaSignInPage();
   const authenticatedHomePage = new AuthenticatedHomePage();
   const profile = new ProfilePage();
   const messagesPage = new MessagesPage();

--- a/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
+++ b/e2e-tests/okta-hosted-login/specs/okta-hosted-login-flow-spec.js
@@ -13,7 +13,12 @@
 'use strict';
 
 const LoginHomePage = require('../../page-objects/shared/login-home-page');
-const OktaSignInPage = require('../../page-objects/okta-signin-page');
+let OktaSignInPage = require('../../page-objects/okta-signin-page');
+
+if (process.env.ORG_OIE_ENABLED) {
+  OktaSignInPage = require('../../page-objects/okta-oie-signin-page');
+}
+
 const AuthenticatedHomePage = require('../../page-objects/shared/authenticated-home-page');
 const ProfilePage = require('../../page-objects/shared/profile-page');
 const MessagesPage = require('../../page-objects/messages-page');

--- a/e2e-tests/page-objects/okta-oie-signin-page.js
+++ b/e2e-tests/page-objects/okta-oie-signin-page.js
@@ -17,24 +17,24 @@ const util = require('./shared/util');
 function input(field) {
   const inputWrap = `o-form-input-${field}`;
   return $(`${util.se(inputWrap)} input`);
-}
+} 
 
-class CustomSignInPage {
+class OktaSignInPage {
 
   constructor() {
-    this.usernameInput = input('username');
-    this.passwordInput = input('password');
-    this.submitButton = $('[data-type="save"]');
+    this.identifierInput = $('[name="identifier"]');
+    this.passcodeInput = $('[name="credentials.passcode"]');
+    this.nextButton = $('[data-type="save"]');
   }
 
   waitForPageLoad() {
-    return util.wait(this.submitButton);
+    return util.wait(this.identifierInput);
   }
 
   login(username, password) {
-    this.usernameInput.sendKeys(username);
-    this.passwordInput.sendKeys(password);
-    return this.submitButton.click();
+    this.identifierInput.sendKeys(username);
+    this.passcodeInput.sendKeys(password);
+    return this.nextButton.click();
   }
 
   urlContains(str) {
@@ -42,4 +42,4 @@ class CustomSignInPage {
   }
 }
 
-module.exports = CustomSignInPage;
+module.exports = OktaSignInPage;


### PR DESCRIPTION
- Adds page object models for OIE sign-in page 
- E2E tests can be now run against OIE enabled orgs for sample repos
- Currently the tests will work when sign-in page has both username + password in the same page. i.e. identifier first flow is not yet supported. Will add that in a separate PR