### PR TITLE
fix CodeLocalValidationScenarioDefinition test

### DIFF
--- a/src/main/groovy/com/okta/test/mock/scenarios/CodeLocalValidationScenarioDefinition.groovy
+++ b/src/main/groovy/com/okta/test/mock/scenarios/CodeLocalValidationScenarioDefinition.groovy
@@ -25,6 +25,7 @@ import org.apache.commons.codec.binary.Base64
 import java.nio.charset.StandardCharsets
 import java.security.KeyPair
 import java.security.KeyPairGenerator
+import java.security.interfaces.RSAPublicKey
 import java.time.Instant
 import java.time.temporal.ChronoUnit
 import java.util.regex.Pattern
@@ -56,9 +57,10 @@ class CodeLocalValidationScenarioDefinition implements ScenarioDefinition {
         keyPairGenerator.initialize(4096)
         KeyPair invalidKeyPair = keyPairGenerator.generateKeyPair()
         KeyPair keyPair = keyPairGenerator.generateKeyPair()
+        RSAPublicKey rsaPublicKey = keyPair.getPublic()
 
-        pubKeyE = Base64.encodeBase64URLSafeString(TestUtils.toIntegerBytes(keyPair.publicKey.getPublicExponent()))
-        pubKeyN = Base64.encodeBase64URLSafeString(TestUtils.toIntegerBytes(keyPair.publicKey.getModulus()))
+        pubKeyE = Base64.encodeBase64URLSafeString(TestUtils.toIntegerBytes(rsaPublicKey.getPublicExponent()))
+        pubKeyN = Base64.encodeBase64URLSafeString(TestUtils.toIntegerBytes(rsaPublicKey.getModulus()))
 
         Instant now = Instant.now()
         accessTokenJwt =  Jwts.builder()


### PR DESCRIPTION
Fixes:

```
Caused by: groovy.lang.MissingPropertyException: No such property: publicKey for class: java.security.KeyPair
Possible solutions: public
        at org.codehaus.groovy.runtime.ScriptBytecodeAdapter.unwrap(ScriptBytecodeAdapter.java:65)
        at org.codehaus.groovy.runtime.callsite.GetEffectivePojoPropertySite.getProperty(GetEffectivePojoPropertySite.java:65)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callGetProperty(AbstractCallSite.java:329)
        at com.okta.test.mock.scenarios.CodeLocalValidationScenarioDefinition.<init>(CodeLocalValidationScenarioDefinition.groovy:60)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
        at org.codehaus.groovy.reflection.CachedConstructor.invoke(CachedConstructor.java:72)
        at org.codehaus.groovy.runtime.callsite.ConstructorSite$ConstructorSiteNoUnwrapNoCoerce.callConstructor(ConstructorSite.java:105)
        at org.codehaus.groovy.runtime.callsite.CallSiteArray.defaultCallConstructor(CallSiteArray.java:59)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:263)
        at org.codehaus.groovy.runtime.callsite.AbstractCallSite.callConstructor(AbstractCallSite.java:268)
        at com.okta.test.mock.scenarios.Scenario.<clinit>(Scenario.groovy:19)
        ... 25 more
```