### PR TITLE
Updates snakeyaml to version 1.31

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
         <dependency>
             <groupId>org.yaml</groupId>
             <artifactId>snakeyaml</artifactId>
-            <version>1.30</version>
+            <version>1.31</version>
         </dependency>
         <dependency>
             <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
Fixes [NVD - CVE-2022-25857](https://nvd.nist.gov/vuln/detail/CVE-2022-25857)