### PR TITLE
Change wiremock-jre to wiremock-standalone

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -91,8 +91,8 @@
         </dependency>
         <dependency>
             <groupId>com.github.tomakehurst</groupId>
-            <artifactId>wiremock-jre8</artifactId>
-            <version>2.35.0</version>
+            <artifactId>wiremock-standalone</artifactId>
+            <version>3.0.0-beta-2</version>
             <exclusions>
                 <exclusion>
                     <groupId>commons-logging</groupId>


### PR DESCRIPTION
`wiremock-jre` -> `wiremock-standalone`

Bumped up version to `3.0.0-beta-2`

This PR is a prereq for merging https://github.com/okta/okta-spring-boot/pull/520