### PR TITLE
Remove explicit version declaration from dependency-check plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,6 @@
                 <plugin>
                     <groupId>org.owasp</groupId>
                     <artifactId>dependency-check-maven</artifactId>
-                    <version>8.0.0</version>
                     <configuration>
                         <!-- no way to exclude some of these issues, and this is only a test lib -->
                         <retireJsAnalyzerEnabled>false</retireJsAnalyzerEnabled>


### PR DESCRIPTION
Version will be pulled in from java-parent.