### PR TITLE
Update testng version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,7 @@
         <dependency>
             <groupId>org.testng</groupId>
             <artifactId>testng</artifactId>
-            <version>7.5</version>
+            <version>7.8</version>
             <scope>compile</scope>
             <exclusions>
                 <exclusion>


### PR DESCRIPTION
Fixing security vulnerability with testng version. Upgraded from v7.5 to the latest v7.8.

See ticket: https://oktainc.atlassian.net/browse/OKTA-609876