### PR TITLE
OKTA-789927: Move away from orb

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,7 +1,7 @@
 version: 2.1
 
 orbs:
-  general-platform-helpers: okta/general-platform-helpers@1.8
+  general-platform-helpers: okta/general-platform-helpers@1.9
 
 aliases:
 
@@ -50,17 +50,11 @@ workflows:
   semgrep:
     jobs:
       - jdk17
-      - general-platform-helpers/job-semgrep-prepare:
-          name: semgrep-prepare
       - general-platform-helpers/job-semgrep-scan:
           name: "Scan with Semgrep"
-          requires:
-            - semgrep-prepare
-      - general-platform-helpers/job-snyk-prepare:
-          name: prepare-snyk
-          requires:
-            - jdk17
+          context:
+            - static-analysis
       - snyk-scan:
           name: execute-snyk
           requires:
-            - prepare-snyk
+            - jdk17

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -56,5 +56,7 @@ workflows:
             - static-analysis
       - snyk-scan:
           name: execute-snyk
+          context:
+            - static-analysis
           requires:
             - jdk17


### PR DESCRIPTION
This moves away from orb-defined jobs when running static analysis tooling.